### PR TITLE
Do not declare not needed dependency

### DIFF
--- a/modules/cli-wrapper/pom.xml
+++ b/modules/cli-wrapper/pom.xml
@@ -15,11 +15,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>


### PR DESCRIPTION
commons-lang3 was marked as test, which would remove it from the fat jar, even if it is a used dependency of the podo-generator-core